### PR TITLE
Improve error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,14 +37,11 @@ pub fn read_embeddings_view(
     let mut reader = BufReader::new(f);
 
     use self::EmbeddingFormat::*;
-    let embeddings = match embedding_format {
+    match embedding_format {
         FinalFusion => ReadEmbeddings::read_embeddings(&mut reader),
         FinalFusionMmap => MmapEmbeddings::mmap_embeddings(&mut reader),
         Word2Vec => ReadWord2Vec::read_word2vec_binary(&mut reader).map(Embeddings::into),
         Text => ReadText::read_text(&mut reader).map(Embeddings::into),
         TextDims => ReadTextDims::read_text_dims(&mut reader).map(Embeddings::into),
     }
-    .context("Cannot read embeddings")?;
-
-    Ok(embeddings)
 }


### PR DESCRIPTION
The context wrapping in read_embeddings_view obscured the underlying
error information, giving errors such as:

Cannot read embeddings: Cannot read embeddings

Do not context-wrap the error to get errors such as:

Cannot read embeddings: Chunk type QuantizedArray cannot be read as
viewable storage

Still not ideal, but better. I also considered with_context, but the
error messages became a bit long and unwieldy.

---

We should stop wrapping errors in library crates using `failure` and switch to library-specific error types. This allows the caller to give error messages tailored to the user.