### PR TITLE
Revamp error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,9 +333,9 @@ dependencies = [
 name = "finalfusion-utils"
 version = "0.10.0"
 dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "finalfusion 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1023,6 +1028,7 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ name = "finalfusion"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 clap = "2"
 env_logger = "0.7"
-failure = "0.1"
 indicatif = "0.12"
 ndarray = "0.13"
 num_cpus = "1"

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,14 +1,13 @@
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read};
 
+use anyhow::{bail, Context, Result};
 use clap::{App, Arg, ArgMatches};
-use failure::{err_msg, Fallible};
 use finalfusion::compat::text::{WriteText, WriteTextDims};
 use finalfusion::compat::word2vec::WriteWord2Vec;
 use finalfusion::io::{ReadEmbeddings, WriteEmbeddings};
 use finalfusion::metadata::Metadata;
 use finalfusion::prelude::*;
-use stdinout::OrExit;
 use toml::Value;
 
 use crate::io::EmbeddingFormat;
@@ -92,21 +91,27 @@ impl FinalfusionApp for ConvertApp {
             )
     }
 
-    fn parse(matches: &ArgMatches) -> Self {
+    fn parse(matches: &ArgMatches) -> Result<Self> {
         let input_filename = matches.value_of(INPUT).unwrap().to_owned();
         let input_format = matches
             .value_of(INPUT_FORMAT)
-            .map(|v| EmbeddingFormat::try_from(v).or_exit("Cannot parse input format", 1))
+            .map(|v| {
+                EmbeddingFormat::try_from(v).context(format!("Cannot parse input format: {}", v))
+            })
+            .transpose()?
             .unwrap();
         let output_filename = matches.value_of(OUTPUT).unwrap().to_owned();
         let output_format = matches
             .value_of(OUTPUT_FORMAT)
-            .map(|v| EmbeddingFormat::try_from(v).or_exit("Cannot parse output format", 1))
+            .map(|v| {
+                EmbeddingFormat::try_from(v).context(format!("Cannot parse output format: {}", v))
+            })
+            .transpose()?
             .unwrap();
 
         let metadata_filename = matches.value_of(METADATA_FILENAME).map(ToOwned::to_owned);
 
-        ConvertApp {
+        Ok(ConvertApp {
             input_filename,
             output_filename,
             input_format,
@@ -114,44 +119,48 @@ impl FinalfusionApp for ConvertApp {
             metadata_filename,
             lossy: matches.is_present(LOSSY),
             unnormalize: matches.is_present(UNNORMALIZE),
-        }
+        })
     }
 
-    fn run(&self) {
+    fn run(&self) -> Result<()> {
         let metadata = self
             .metadata_filename
             .as_ref()
             .map(read_metadata)
+            .transpose()?
             .map(Metadata::new);
 
-        let mut embeddings = read_embeddings(&self.input_filename, self.input_format, self.lossy);
+        let mut embeddings = read_embeddings(&self.input_filename, self.input_format, self.lossy)?;
 
         // Overwrite metadata if provided, otherwise retain existing metadata.
         if metadata.is_some() {
             embeddings.set_metadata(metadata);
         }
 
-        write_embeddings(&embeddings, &self).or_exit("Cannot write embeddings", 1)
+        write_embeddings(&embeddings, &self).context("Cannot write embeddings")
     }
 }
 
-fn read_metadata(filename: impl AsRef<str>) -> Value {
-    let f = File::open(filename.as_ref()).or_exit("Cannot open metadata file", 1);
+fn read_metadata(filename: impl AsRef<str>) -> Result<Value> {
+    let f = File::open(filename.as_ref())
+        .context(format!("Cannot open metadata file: {}", filename.as_ref()))?;
     let mut reader = BufReader::new(f);
     let mut buf = String::new();
     reader
         .read_to_string(&mut buf)
-        .or_exit("Cannot read metadata", 1);
-    buf.parse::<Value>()
-        .or_exit("Cannot parse metadata TOML", 1)
+        .context(format!("Cannot read metadata from {}", filename.as_ref()))?;
+    buf.parse::<Value>().context(format!(
+        "Cannot parse metadata TOML from {}",
+        filename.as_ref()
+    ))
 }
 
 fn read_embeddings(
     filename: &str,
     embedding_format: EmbeddingFormat,
     lossy: bool,
-) -> Embeddings<VocabWrap, StorageWrap> {
-    let f = File::open(filename).or_exit("Cannot open embeddings file", 1);
+) -> Result<Embeddings<VocabWrap, StorageWrap>> {
+    let f = File::open(filename).context(format!("Cannot open embeddings file: {}", filename))?;
     let mut reader = BufReader::new(f);
 
     use self::EmbeddingFormat::*;
@@ -169,21 +178,27 @@ fn read_embeddings(
         (TextDims, true) => ReadTextDims::read_text_dims_lossy(&mut reader).map(Embeddings::into),
         (TextDims, false) => ReadTextDims::read_text_dims(&mut reader).map(Embeddings::into),
     }
-    .or_exit("Cannot read embeddings", 1)
+    .context(format!(
+        "Cannot read {} embeddings from {}",
+        embedding_format, filename
+    ))
 }
 
 fn write_embeddings(
     embeddings: &Embeddings<VocabWrap, StorageWrap>,
     config: &ConvertApp,
-) -> Fallible<()> {
-    let f = File::create(&config.output_filename).or_exit("Cannot create embeddings file", 1);
+) -> Result<()> {
+    let f = File::create(&config.output_filename).context(format!(
+        "Cannot create embeddings file: {}",
+        config.output_filename
+    ))?;
     let mut writer = BufWriter::new(f);
 
     use self::EmbeddingFormat::*;
     match config.output_format {
-        FastText => return Err(err_msg("Writing to the fastText format is not supported")),
+        FastText => bail!("Writing to the fastText format is not supported"),
         FinalFusion => embeddings.write_embeddings(&mut writer)?,
-        FinalFusionMmap => return Err(err_msg("Writing to this format is not supported")),
+        FinalFusionMmap => bail!("Writing to memory-mapped finalfusion file is not supported"),
         Word2Vec => embeddings.write_word2vec_binary(&mut writer, config.unnormalize)?,
         Text => embeddings.write_text(&mut writer, config.unnormalize)?,
         TextDims => embeddings.write_text_dims(&mut writer, config.unnormalize)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::io::stdout;
 
+use anyhow::Result;
 use clap::{App, AppSettings, Arg, Shell, SubCommand};
 
 mod analogy;
@@ -25,7 +26,7 @@ static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
     AppSettings::SubcommandRequiredElseHelp,
 ];
 
-fn main() {
+fn main() -> Result<()> {
     // Known subapplications.
     let apps = vec![
         analogy::AnalogyApp::app(),
@@ -49,7 +50,7 @@ fn main() {
 
     match matches.subcommand_name().unwrap() {
         "analogy" => {
-            analogy::AnalogyApp::parse(matches.subcommand_matches("analogy").unwrap()).run()
+            analogy::AnalogyApp::parse(matches.subcommand_matches("analogy").unwrap())?.run()
         }
         "completions" => {
             let shell = matches
@@ -58,22 +59,23 @@ fn main() {
                 .value_of("shell")
                 .unwrap();
             write_completion_script(cli, shell.parse::<Shell>().unwrap());
+            Ok(())
         }
         "compute-accuracy" => compute_accuracy::ComputeAccuracyApp::parse(
             matches.subcommand_matches("compute-accuracy").unwrap(),
-        )
+        )?
         .run(),
         "convert" => {
-            convert::ConvertApp::parse(matches.subcommand_matches("convert").unwrap()).run()
+            convert::ConvertApp::parse(matches.subcommand_matches("convert").unwrap())?.run()
         }
         "metadata" => {
-            metadata::MetadataApp::parse(matches.subcommand_matches("metadata").unwrap()).run()
+            metadata::MetadataApp::parse(matches.subcommand_matches("metadata").unwrap())?.run()
         }
         "quantize" => {
-            quantize::QuantizeApp::parse(matches.subcommand_matches("quantize").unwrap()).run()
+            quantize::QuantizeApp::parse(matches.subcommand_matches("quantize").unwrap())?.run()
         }
         "similar" => {
-            similar::SimilarApp::parse(matches.subcommand_matches("similar").unwrap()).run()
+            similar::SimilarApp::parse(matches.subcommand_matches("similar").unwrap())?.run()
         }
         _unknown => unreachable!(),
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,9 +1,13 @@
+use anyhow::Result;
 use clap::{App, ArgMatches};
 
-pub trait FinalfusionApp {
+pub trait FinalfusionApp
+where
+    Self: Sized,
+{
     fn app() -> App<'static, 'static>;
 
-    fn parse(matches: &ArgMatches) -> Self;
+    fn parse(matches: &ArgMatches) -> Result<Self>;
 
-    fn run(&self);
+    fn run(&self) -> Result<()>;
 }


### PR DESCRIPTION
- Replace `failure` dependency by `anyhow`. `anyhow` is more or less
  the successor of `failure` for applications. It uses the standard
  library's `Error` trait rather than the custom `Fail` trait
- Bubble up errors all the way up to `main`. Since `anyhow` actually
  gives us nice error message, the OrExit trait is not needed anymore.

---

This mirrors the error handling changes in finalfrontier.