### PR TITLE
Add reconstruct subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "finalfusion"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -337,7 +337,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "finalfusion 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "finalfusion 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1080,7 +1080,7 @@ dependencies = [
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469"
-"checksum finalfusion 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6edb264178274026d963bc02770cf9dc0b3e6ba6dbe2000209f2303b17b2f63a"
+"checksum finalfusion 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "24bf09b1ca0587f6298a58296ec201dcfc83af291b41258ea4ea21b010f7fc65"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ndarray = "0.13"
 num_cpus = "1"
 rayon = "1"
 reductive = "0.4"
-finalfusion = "0.12"
+finalfusion = "0.12.1"
 stdinout = "0.4"
 toml = "0.5"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,14 @@ mod metadata;
 
 mod quantize;
 
+mod reconstruct;
+
 mod similar;
 
 mod traits;
 pub use self::traits::FinalfusionApp;
+
+pub mod util;
 
 static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
     AppSettings::DontCollapseArgsInUsage,
@@ -34,6 +38,7 @@ fn main() -> Result<()> {
         convert::ConvertApp::app(),
         metadata::MetadataApp::app(),
         quantize::QuantizeApp::app(),
+        reconstruct::ReconstructApp::app(),
         similar::SimilarApp::app(),
     ];
 
@@ -73,6 +78,10 @@ fn main() -> Result<()> {
         }
         "quantize" => {
             quantize::QuantizeApp::parse(matches.subcommand_matches("quantize").unwrap())?.run()
+        }
+        "reconstruct" => {
+            reconstruct::ReconstructApp::parse(matches.subcommand_matches("reconstruct").unwrap())?
+                .run()
         }
         "similar" => {
             similar::SimilarApp::parse(matches.subcommand_matches("similar").unwrap())?.run()

--- a/src/reconstruct.rs
+++ b/src/reconstruct.rs
@@ -1,0 +1,86 @@
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+
+use anyhow::{Context, Result};
+use clap::{App, Arg, ArgMatches};
+use finalfusion::io::WriteEmbeddings;
+use finalfusion::norms::NdNorms;
+use finalfusion::prelude::*;
+use finalfusion::storage::Reconstruct;
+use finalfusion::storage::{NdArray, QuantizedArray};
+use finalfusion::vocab::Vocab;
+use ndarray::{s, Array2};
+
+use crate::util::l2_normalize_array;
+use crate::FinalfusionApp;
+
+// Argument constants
+static INPUT: &str = "INPUT";
+static OUTPUT: &str = "OUTPUT";
+
+pub struct ReconstructApp {
+    input_filename: String,
+    output_filename: String,
+}
+
+impl FinalfusionApp for ReconstructApp {
+    fn app() -> App<'static, 'static> {
+        App::new("reconstruct")
+            .about("Reconstruct quantized embedding matrices")
+            .arg(
+                Arg::with_name(INPUT)
+                    .help("quantized finalfusion embeddings")
+                    .index(1)
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name(OUTPUT)
+                    .help("reconstructed finalfusion embeddings")
+                    .index(2)
+                    .required(true),
+            )
+    }
+
+    fn parse(matches: &ArgMatches) -> Result<Self> {
+        // Arguments
+        let input_filename = matches.value_of(INPUT).unwrap().to_owned();
+        let output_filename = matches.value_of(OUTPUT).unwrap().to_owned();
+
+        Ok(ReconstructApp {
+            input_filename,
+            output_filename,
+        })
+    }
+
+    fn run(&self) -> Result<()> {
+        let f = File::open(&self.input_filename).context("Cannot open embeddings file")?;
+        let mut reader = BufReader::new(f);
+        let embeddings: Embeddings<VocabWrap, QuantizedArray> =
+            Embeddings::read_embeddings(&mut reader)
+                .context("Cannot read quantized embedding matrix")?;
+
+        let (metadata, vocab, quantized_storage, norms) = embeddings.into_parts();
+
+        let mut array: Array2<f32> = quantized_storage.reconstruct().into();
+
+        let norms = match norms {
+            Some(norms) => norms,
+            None => NdNorms::new(l2_normalize_array(
+                array.view_mut().slice_mut(s![0..vocab.words_len(), ..]),
+            )),
+        };
+
+        let embeddings = Embeddings::new(metadata, vocab, array.into(), norms);
+
+        write_embeddings(&embeddings, &self.output_filename)
+    }
+}
+
+fn write_embeddings(embeddings: &Embeddings<VocabWrap, NdArray>, filename: &str) -> Result<()> {
+    let f =
+        File::create(filename).context(format!("Cannot create embeddings file: {}", filename))?;
+    let mut writer = BufWriter::new(f);
+    embeddings
+        .write_embeddings(&mut writer)
+        .context("Cannot write embeddings")
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,20 @@
+use ndarray::{Array1, ArrayViewMut1, ArrayViewMut2};
+
+pub fn l2_normalize(mut v: ArrayViewMut1<f32>) -> f32 {
+    let norm = v.dot(&v).sqrt();
+
+    if norm != 0. {
+        v /= norm;
+    }
+
+    norm
+}
+
+pub fn l2_normalize_array(mut v: ArrayViewMut2<f32>) -> Array1<f32> {
+    let mut norms = Vec::with_capacity(v.nrows());
+    for embedding in v.outer_iter_mut() {
+        norms.push(l2_normalize(embedding));
+    }
+
+    norms.into()
+}


### PR DESCRIPTION
Sometimes you want to evaluate or explore your quantized
embeddings (which have some loss compared to the original embeddings),
but evaluation that uses similarity queries is prohibitively expensive
on quantized embeddings. For such cases, this subcommand allows you to
convert quantized storage to array storage.