### PR TITLE
Add an `--similarity` option to the `similar`/`analogy` subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "finalfusion"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -314,7 +314,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "finalfusion 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "finalfusion 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1037,7 +1037,7 @@ dependencies = [
 "checksum failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 "checksum failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 "checksum filetime 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
-"checksum finalfusion 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "24bf09b1ca0587f6298a58296ec201dcfc83af291b41258ea4ea21b010f7fc65"
+"checksum finalfusion 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "69282af3a78bd214774cb55a0995fd02b3f290a1328c3da128d901d8e46236d0"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ndarray = "0.13"
 num_cpus = "1"
 rayon = "1"
 reductive = "0.4"
-finalfusion = "0.12.1"
+finalfusion = "0.12.2"
 stdinout = "0.4"
 toml = "0.5"
 

--- a/src/analogy.rs
+++ b/src/analogy.rs
@@ -8,6 +8,7 @@ use finalfusion::similarity::Analogy;
 use stdinout::Input;
 
 use crate::io::{read_embeddings_view, EmbeddingFormat};
+use crate::similarity::SimilarityMeasure;
 use crate::FinalfusionApp;
 
 pub struct AnalogyApp {
@@ -16,6 +17,7 @@ pub struct AnalogyApp {
     input_filename: Option<String>,
     excludes: [bool; 3],
     k: usize,
+    similarity: SimilarityMeasure,
 }
 
 impl FinalfusionApp for AnalogyApp {
@@ -45,6 +47,7 @@ impl FinalfusionApp for AnalogyApp {
                     .takes_value(true)
                     .default_value("10"),
             )
+            .arg(SimilarityMeasure::new_clap_arg())
             .arg(
                 Arg::with_name("EMBEDDINGS")
                     .help("Embeddings file")
@@ -90,12 +93,15 @@ impl FinalfusionApp for AnalogyApp {
             })
             .unwrap_or_else(|| [true, true, true]);
 
+        let similarity = SimilarityMeasure::parse_clap_matches(&matches)?;
+
         Ok(AnalogyApp {
             embeddings_filename,
             embedding_format,
             input_filename,
             excludes,
             k,
+            similarity,
         })
     }
 
@@ -131,7 +137,7 @@ impl FinalfusionApp for AnalogyApp {
             };
 
             for analogy in results {
-                println!("{}\t{}", analogy.word, analogy.similarity);
+                println!("{}\t{}", analogy.word, self.similarity.to_f32(&analogy));
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ mod select;
 
 mod similar;
 
+mod similarity;
+
 mod traits;
 pub use self::traits::FinalfusionApp;
 

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -8,12 +8,14 @@ use stdinout::Input;
 
 use super::FinalfusionApp;
 use crate::io::{read_embeddings_view, EmbeddingFormat};
+use crate::similarity::SimilarityMeasure;
 
 pub struct SimilarApp {
     embeddings_filename: String,
     embedding_format: EmbeddingFormat,
     input: Option<String>,
     k: usize,
+    similarity: SimilarityMeasure,
 }
 
 impl FinalfusionApp for SimilarApp {
@@ -43,6 +45,7 @@ impl FinalfusionApp for SimilarApp {
                     .takes_value(true)
                     .default_value("10"),
             )
+            .arg(SimilarityMeasure::new_clap_arg())
             .arg(
                 Arg::with_name("EMBEDDINGS")
                     .help("Embeddings file")
@@ -75,7 +78,10 @@ impl FinalfusionApp for SimilarApp {
             .transpose()?
             .unwrap();
 
+        let similarity = SimilarityMeasure::parse_clap_matches(&matches)?;
+
         Ok(SimilarApp {
+            similarity,
             input,
             embeddings_filename,
             embedding_format,
@@ -105,7 +111,7 @@ impl FinalfusionApp for SimilarApp {
             };
 
             for similar in results {
-                println!("{}\t{}", similar.word, similar.similarity);
+                println!("{}\t{}", similar.word, self.similarity.to_f32(&similar));
             }
         }
 

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -1,0 +1,73 @@
+use std::convert::TryFrom;
+use std::fmt;
+
+use anyhow::{anyhow, Context, Error, Result};
+use clap::{Arg, ArgMatches};
+use finalfusion::similarity::WordSimilarityResult;
+
+const SIMILARITY: &str = "similarity";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SimilarityMeasure {
+    Angular,
+    Cosine,
+}
+
+impl SimilarityMeasure {
+    pub fn new_clap_arg() -> Arg<'static, 'static> {
+        Arg::with_name(SIMILARITY)
+            .short("s")
+            .long("similarity")
+            .value_name("SIMILARITY")
+            .takes_value(true)
+            .default_value("cosine")
+            .possible_values(&["angular", "cosine"])
+            .help("Similarity measure")
+    }
+
+    pub fn parse_clap_matches(matches: &ArgMatches) -> Result<Self> {
+        let measure = matches
+            .value_of(SIMILARITY)
+            .map(|s| {
+                SimilarityMeasure::try_from(s)
+                    .context(format!("Cannot parse similarity measure: {}", s))
+            })
+            .transpose()?
+            .unwrap();
+        Ok(measure)
+    }
+
+    pub fn to_f32(&self, result: &WordSimilarityResult) -> f32 {
+        use self::SimilarityMeasure::*;
+        match self {
+            Angular => result.angular_similarity(),
+            Cosine => result.cosine_similarity(),
+        }
+    }
+}
+
+impl TryFrom<&str> for SimilarityMeasure {
+    type Error = Error;
+
+    fn try_from(format: &str) -> Result<Self> {
+        use self::SimilarityMeasure::*;
+
+        match format {
+            "angular" => Ok(Angular),
+            "cosine" => Ok(Cosine),
+            unknown => Err(anyhow!("Unknown similarity measure: {}", unknown)),
+        }
+    }
+}
+
+impl fmt::Display for SimilarityMeasure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use SimilarityMeasure::*;
+        let s = match self {
+            Angular => "angular",
+            Cosine => "cosine",
+        };
+
+        f.write_str(s)
+    }
+}


### PR DESCRIPTION
This option allows selecting the similarity measure. Cosine similarity
is still the default, but `angular` can be used to switch to angular
similarity.