### PR TITLE
Override Intel CPU detection

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "intel-mkl")]
+use std::os::raw::c_int;
+
 use ndarray::{Array1, ArrayViewMut1, ArrayViewMut2};
 
 pub fn l2_normalize(mut v: ArrayViewMut1<f32>) -> f32 {
@@ -17,4 +20,11 @@ pub fn l2_normalize_array(mut v: ArrayViewMut2<f32>) -> Array1<f32> {
     }
 
     norms.into()
+}
+
+#[cfg(feature = "intel-mkl")]
+#[allow(dead_code)]
+#[no_mangle]
+extern "C" fn mkl_serv_intel_cpu_true() -> c_int {
+    1
 }


### PR DESCRIPTION
This makes MKL choose kernels based on actual CPU features, fixing
performance on Ryzen machines.