### PR TITLE
Clippy fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,14 +40,25 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: actions-rs/cargo@v1
+        name: Test
+        with:
+          command: test
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.53.0
+          override: true
           components: clippy
       - uses: actions-rs/cargo@v1
         name: Clippy
         with:
           command: clippy
           args: -- -D warnings
-      - uses: actions-rs/cargo@v1
-        name: Test
-        with:
-          command: test
 

--- a/src/analogy.rs
+++ b/src/analogy.rs
@@ -137,7 +137,7 @@ impl FinalfusionApp for AnalogyApp {
             };
 
             for analogy in results {
-                println!("{}\t{}", analogy.word(), self.similarity.to_f32(&analogy));
+                println!("{}\t{}", analogy.word(), self.similarity.as_f32(&analogy));
             }
         }
 

--- a/src/similar.rs
+++ b/src/similar.rs
@@ -81,11 +81,11 @@ impl FinalfusionApp for SimilarApp {
         let similarity = SimilarityMeasure::parse_clap_matches(&matches)?;
 
         Ok(SimilarApp {
-            similarity,
-            input,
             embeddings_filename,
             embedding_format,
+            input,
             k,
+            similarity,
         })
     }
 
@@ -111,7 +111,7 @@ impl FinalfusionApp for SimilarApp {
             };
 
             for similar in results {
-                println!("{}\t{}", similar.word(), self.similarity.to_f32(&similar));
+                println!("{}\t{}", similar.word(), self.similarity.as_f32(&similar));
             }
         }
 

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -37,7 +37,7 @@ impl SimilarityMeasure {
         Ok(measure)
     }
 
-    pub fn to_f32(&self, result: &WordSimilarityResult) -> f32 {
+    pub fn as_f32(&self, result: &WordSimilarityResult) -> f32 {
         use self::SimilarityMeasure::*;
         match self {
             Angular => result.angular_similarity(),


### PR DESCRIPTION
- Fix clippy warnings
- Pin Rust to 1.53.0 for Clippy test
