### PR TITLE
MKL support improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ opq = ["reductive/opq-train"]
 
 # BLAS and LAPACK libraries.
 accelerate = ["opq", "ndarray/blas", "accelerate-src"]
-intel-mkl = ["opq", "ndarray/blas", "intel-mkl-src/mkl-static-ilp64-seq", "intel-mkl-src/download"]
-intel-mkl-amd = ["opq", "ndarray/blas", "intel-mkl-src/mkl-dynamic-ilp64-seq"]
+intel-mkl = ["opq", "ndarray/blas", "intel-mkl-src/mkl-static-lp64-seq", "intel-mkl-src/download"]
+intel-mkl-amd = ["opq", "ndarray/blas", "intel-mkl-src/mkl-dynamic-lp64-seq"]
 netlib = ["opq", "ndarray/blas", "netlib-src"]
 openblas = ["opq", "ndarray/blas", "openblas-src"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@ extern crate openblas_src;
 #[cfg(feature = "intel-mkl")]
 extern crate intel_mkl_src;
 
+#[cfg(feature = "intel-mkl-amd")]
+extern crate intel_mkl_src;
+
 use std::io::stdout;
 
 use anyhow::Result;


### PR DESCRIPTION
Wanted to quantize embeddings on a Ryzen CPU, found two issues:

* `intel-mkl-amd` does not add link flags for the library and fails with symbols that cannot be found.
* Quantization fails in eigenvalue decomposition, since we are linking to the 64-bit integer interface, but we should be using the 32-bit interface.