### PR TITLE
Use cross for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,24 +30,30 @@ jobs:
   release-linux:
     needs: ['create-release']
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
-        target: x86_64-unknown-linux-musl
         override: true
     - uses: actions-rs/cargo@v1
       with:
+        use-cross: true
         command: build
-        args: --release
+        args: --release --target=${{ matrix.target }}
     - name: Create release archive
       id: create_archive
       run: |
-        ARCHIVE=finalfusion-${{ needs.create-release.outputs.ff_utils_version }}-x86_64-unknown-linux-musl.tar.gz
-        strip target/release/finalfusion
-        tar -czvf ${ARCHIVE} -C target/release finalfusion
+        ARCHIVE=finalfusion-${{ needs.create-release.outputs.ff_utils_version }}-${{ matrix.target }}.tar.gz
+        tar -czvf ${ARCHIVE} -C target/${{ matrix.target }}/release finalfusion
         echo ::set-output name=ASSET::$ARCHIVE
 
     - uses: actions/upload-release-asset@v1.0.1
@@ -61,7 +67,7 @@ jobs:
 
   release-linux-mkl:
     needs: ['create-release']
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
@@ -70,14 +76,15 @@ jobs:
         toolchain: stable
     - uses: actions-rs/cargo@v1
       with:
+        use-cross: true
         command: build
-        args: --release --features intel-mkl
+        args: --target=x86_64-unknown-linux-gnu --release --features intel-mkl
     - name: Create release archive
       id: create_archive
       run: |
         ARCHIVE=finalfusion-${{ needs.create-release.outputs.ff_utils_version }}-x86_64-unknown-linux-gnu-mkl.tar.gz
-        strip target/release/finalfusion
-        tar -czvf ${ARCHIVE} -C target/release finalfusion
+        strip target/x86_64-unknown-linux-gnu/release/finalfusion
+        tar -czvf ${ARCHIVE} -C target/x86_64-unknown-linux-gnu/release finalfusion
         echo ::set-output name=ASSET::$ARCHIVE
     - uses: actions/upload-release-asset@v1.0.1
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "netlib-src",
  "num_cpus",
  "openblas-src",
+ "openssl",
  "rayon",
  "reductive",
  "stdinout",
@@ -347,6 +348,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "getrandom"
@@ -637,16 +653,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
 name = "openblas-src"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84629d1d4f9f40d3f9e4756dae33c6af50d3c2fcc186558dac65bf55141ade6b"
 
 [[package]]
+name = "openssl"
+version = "0.10.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-src"
+version = "111.16.0+1.1.1l"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "openssl-sys"
@@ -657,6 +702,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,16 @@ version = "0.9"
 optional = true
 features = ["system"]
 
+[build-dependencies]
+openssl = { version = "0.10", optional = true }
+
 [features]
 default = []
 opq = ["reductive/opq-train"]
 
 # BLAS and LAPACK libraries.
 accelerate = ["opq", "ndarray/blas", "accelerate-src"]
-intel-mkl = ["opq", "ndarray/blas", "intel-mkl-src/mkl-static-lp64-seq", "intel-mkl-src/download"]
+intel-mkl = ["opq", "ndarray/blas", "intel-mkl-src/mkl-static-lp64-seq", "intel-mkl-src/download", "openssl/vendored"]
 intel-mkl-amd = ["opq", "ndarray/blas", "intel-mkl-src/mkl-dynamic-lp64-seq"]
 netlib = ["opq", "ndarray/blas", "netlib-src"]
 openblas = ["opq", "ndarray/blas", "openblas-src"]


### PR DESCRIPTION
We were using Ubuntu 16.04 for glibc release builds, but GitHub does not
provide 16.04 runners anymore. We could upgrade to 18.04, but that is a
fairly recent release and would remove support for older RHEL/CentOS
versions.

cross uses 2.15 for release builds, which gives us a lot of backwards
compatibility. While at it, also build:

- aarch64-unknown-linux-gnu
- aarch64-unknown-linux-musl
- x86_64-unknown-linux-gnu